### PR TITLE
fix(npm script): change import statement to require call

### DIFF
--- a/scripts/prePublishOnly.js
+++ b/scripts/prePublishOnly.js
@@ -1,5 +1,5 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { copySync } from 'fs-extra';
+const { copySync } = require('fs-extra');
 
 try {
     copySync('./dist', '.', { overwrite: true });


### PR DESCRIPTION
As node does not support import statements yet we will have to stick to require statements only

Fixes #27 